### PR TITLE
Feature/16 improve argument value type determination

### DIFF
--- a/src/Argument.php
+++ b/src/Argument.php
@@ -48,6 +48,18 @@ class Argument
             return self::ARGUMENT_VALUE_TYPE_OBJECT;
         }
 
+        if(is_float($argument)) {
+            return self::ARGUMENT_VALUE_TYPE_FLOAT;
+        }
+
+        if(is_int($argument)) {
+            return self::ARGUMENT_VALUE_TYPE_INT;
+        }
+
+        if(is_string($argument)) {
+            return self::ARGUMENT_VALUE_TYPE_STRING;
+        }
+
         return self::ARGUMENT_VALUE_TYPE_OTHER;
     }
 

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -174,4 +174,28 @@ class ArgumentTest extends TestCase
         $argument = new Argument($argument);
         $this->assertSame($expected, $argument->getType());
     }
+
+    public static function SimpleValueTypesArgumentsProvider(): array
+    {
+        return [
+            [0.23, Argument::ARGUMENT_VALUE_TYPE_FLOAT],
+            [0.23754, Argument::ARGUMENT_VALUE_TYPE_FLOAT],
+            [20, Argument::ARGUMENT_VALUE_TYPE_INT],
+            [1000, Argument::ARGUMENT_VALUE_TYPE_INT],
+            ["0.0", Argument::ARGUMENT_VALUE_TYPE_STRING],
+            ["10.20", Argument::ARGUMENT_VALUE_TYPE_STRING],
+            ["ABCD", Argument::ARGUMENT_VALUE_TYPE_STRING],
+            ["abcd", Argument::ARGUMENT_VALUE_TYPE_STRING],
+            ["!^&$%", Argument::ARGUMENT_VALUE_TYPE_STRING],
+        ];
+    }
+
+    /**
+     * @dataProvider SimpleValueTypesArgumentsProvider
+     */
+    public function testWhenArgumentValueIsASimpleDataType(mixed $argument, int $expected): void
+    {
+        $argument = new Argument($argument);
+        $this->assertSame($expected, $argument->getType());
+    }
 }


### PR DESCRIPTION
- Implement the necessary logic to determine type (from below list for now and could be extended further later) of the value of Argument
   - Boolean
   - Simple Value(int. string, float etc)
   - Sequential Array
   - Associative Array
   - Object

- Arrange the necessary unit tests to validate the value type determination logic.

This closes #16 

Unit Tests Results

```
/app # ./vendor/bin/phpunit --testdox tests/ArgumentTest.php
PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.6
Configuration: /app/phpunit.xml

...............................                                   31 / 31 (100%)

Time: 00:00.008, Memory: 8.00 MB

Argument (AntonDPerera\PHPAttributesReader\Tests\Argument)
 ✔ When argument value is empty with data set 0
 ✔ When argument value is empty with data set 1
 ✔ When argument value is empty with data set 2
 ✔ When argument value is empty with data set 3
 ✔ When argument value is empty with data set 4
 ✔ When argument value is boolean with data set 0
 ✔ When argument value is boolean with data set 1
 ✔ When argument value is sequential array with data set 0
 ✔ When argument value is sequential array with data set 1
 ✔ When argument value is sequential array with data set 2
 ✔ When argument value is sequential array with data set 3
 ✔ When argument value is associative array with data set 0
 ✔ When argument value is associative array with data set 1
 ✔ When argument value is associative array with data set 2
 ✔ When argument value is associative array with data set 3
 ✔ When argument value is associative array with data set 4
 ✔ When argument value is associative array with data set 5
 ✔ When argument value is object with data set 0
 ✔ When argument value is object with data set 1
 ✔ When argument value is object with data set 2
 ✔ When argument value is object with data set 3
 ✔ When argument value is object with data set 4
 ✔ When argument value is a simple data type with data set 0
 ✔ When argument value is a simple data type with data set 1
 ✔ When argument value is a simple data type with data set 2
 ✔ When argument value is a simple data type with data set 3
 ✔ When argument value is a simple data type with data set 4
 ✔ When argument value is a simple data type with data set 5
 ✔ When argument value is a simple data type with data set 6
 ✔ When argument value is a simple data type with data set 7
 ✔ When argument value is a simple data type with data set 8

OK (31 tests, 31 assertions)
```