### PR TITLE
feat: Renamed Reader class to AttributesReader and updated usages and…

### DIFF
--- a/src/AttributesReader.php
+++ b/src/AttributesReader.php
@@ -10,7 +10,7 @@ use AntonDPerera\PHPAttributesReader\Traits\ClassAttributesSupport;
 use AntonDPerera\PHPAttributesReader\Traits\MethodAttributesSupport;
 use AntonDPerera\PHPAttributesReader\Traits\PropertyAttributesSupport;
 
-class Reader
+class AttributesReader
 {
     use ClassAttributesSupport;
     use MethodAttributesSupport;

--- a/tests/ReaderClassAttributesTest.php
+++ b/tests/ReaderClassAttributesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AntonDPerera\PHPAttributesReader\Tests;
 
 use PHPUnit\Framework\TestCase;
-use AntonDPerera\PHPAttributesReader\Reader;
+use AntonDPerera\PHPAttributesReader\AttributesReader;
 use AntonDPerera\PHPAttributesReader\Exceptions\InvalidClassException;
 use AntonDPerera\PHPAttributesReader\Exceptions\ClassNotFoundException;
 use AntonDPerera\PHPAttributesReader\Exceptions\ClassAttributeNotFoundException;
@@ -32,7 +32,7 @@ class ReaderClassAttributesTest extends TestCase
     public function testExceptionWhenInvalidClassValueGiven(?string $class = null): void
     {
         $this->expectException(InvalidClassException::class);
-        new Reader($class);
+        new AttributesReader($class);
     }
 
     public static function nonExistingClassProvider(): array
@@ -51,7 +51,7 @@ class ReaderClassAttributesTest extends TestCase
     public function testExceptionWhenNonExistingClassGiven(?string $class = null): void
     {
         $this->expectException(ClassNotFoundException::class);
-        new Reader($class);
+        new AttributesReader($class);
     }
 
     public static function classWithoutAttributesProvider(): array
@@ -66,7 +66,7 @@ class ReaderClassAttributesTest extends TestCase
      */
     public function testGetClassAttributesWithNoAttributesClass(string $class, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attributes = $reader->getClassAttributes();
         $this->assertSame($expected, $attributes);
     }
@@ -86,7 +86,7 @@ class ReaderClassAttributesTest extends TestCase
      */
     public function testHasClassAttributes(string $class, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attributes = $reader->hasClassAttributes();
         $this->assertSame($expected, $attributes);
     }
@@ -106,7 +106,7 @@ class ReaderClassAttributesTest extends TestCase
      */
     public function testGetClassAttributesWithoutArguments(string $class, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attribute = $reader->getClassAttributes()[$attribute_name];
         $actual = $attribute->getArguments();
         $this->assertSame($expected, $actual);
@@ -132,7 +132,7 @@ class ReaderClassAttributesTest extends TestCase
      */
     public function testGetClassAttributesWithArguments(string $class, string $attribute_name, int $argument_index, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attribute = $reader->getClassAttributes()[$attribute_name];
         $argument = $attribute->getArguments()[$argument_index];
         $this->assertEquals($expected, $argument->getValue());
@@ -151,7 +151,7 @@ class ReaderClassAttributesTest extends TestCase
     public function testExceptionWhenNonExistingAttributeNameGiven(string $class = null, string $attribute_name): void
     {
         $this->expectException(ClassAttributeNotFoundException::class);
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $reader->getClassAttribute($attribute_name);
     }
 
@@ -192,7 +192,7 @@ class ReaderClassAttributesTest extends TestCase
      */
     public function testGetClassAttributeByAttributeName(string $class, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getClassAttribute($attribute_name))->getName();
         $this->assertSame($expected, $actual);
     }

--- a/tests/ReaderMethodAttributesTest.php
+++ b/tests/ReaderMethodAttributesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AntonDPerera\PHPAttributesReader\Tests;
 
 use PHPUnit\Framework\TestCase;
-use AntonDPerera\PHPAttributesReader\Reader;
+use AntonDPerera\PHPAttributesReader\AttributesReader;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\MethodAttributes\DummyClass0WithoutMethodAttributes;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\MethodAttributes\DummyClass1WithMethodAttributes;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\MethodAttributes\DummyClass2WithMethodAttributes;
@@ -26,7 +26,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testGetAllMethodAttributesWithNoAttributes(string $class, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attributes = $reader->getMethodAttributes();
         $this->assertSame($expected, $attributes);
     }
@@ -60,7 +60,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testGetAllMethodAttributesWithAttributes(string $class, string $method_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getMethodAttributes()[$method_name][$attribute_name])->getName();
         $this->assertSame($expected, $actual);
     }
@@ -75,7 +75,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testgetMethodAttributesWithNonExistingMethodName(string $class, string $method_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(MethodNotFoundException::class);
         $reader->getMethodAttributes($method_name);
     }
@@ -110,7 +110,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testgetMethodAttributesWithExistingMethodName(string $class, string $method_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getMethodAttributes($method_name)[$attribute_name])->getName();
         $this->assertSame($expected, $actual);
     }
@@ -125,7 +125,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testGetMethodAttributeByMethodNameWithNonExistingMethodName(string $class, string $method_name, string $attribute_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(MethodNotFoundException::class);
         $reader->getMethodAttribute($method_name, $attribute_name);
     }
@@ -140,7 +140,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testGetMethodAttributeByMethodNameWithNonExistingAttributeName(string $class, string $method_name, string $attribute_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(MethodAttributeNotFoundException::class);
         $reader->getMethodAttribute($method_name, $attribute_name);
     }
@@ -175,7 +175,7 @@ class ReaderMethodAttributesTest extends TestCase
      */
     public function testgetMethodAttributeWithExistingMethodName(string $class, string $method_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getMethodAttribute($method_name,$attribute_name))->getName();
         $this->assertSame($expected, $actual);
     }

--- a/tests/ReaderPropertyAttributesTest.php
+++ b/tests/ReaderPropertyAttributesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AntonDPerera\PHPAttributesReader\Tests;
 
 use PHPUnit\Framework\TestCase;
-use AntonDPerera\PHPAttributesReader\Reader;
+use AntonDPerera\PHPAttributesReader\AttributesReader;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\PropertyAttributes\DummyClass0WithoutPropertyAttributes;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\PropertyAttributes\DummyClass1WithPropertyAttributes;
 use AntonDPerera\PHPAttributesReader\Tests\Fixtures\PropertyAttributes\DummyClass2WithPropertyAttributes;
@@ -26,7 +26,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testGetAllPropertyAttributesWithNoAttributes(string $class, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $attributes = $reader->getPropertyAttributes();
         $this->assertSame($expected, $attributes);
     }
@@ -60,7 +60,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testGetAllPropertyAttributesWithAttributes(string $class, string $property_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getPropertyAttributes()[$property_name][$attribute_name])->getName();
         $this->assertSame($expected, $actual);
     }
@@ -75,7 +75,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testgetPropertyAttributesWithNonExistingPropertyName(string $class, string $property_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(PropertyNotFoundException::class);
         $reader->getPropertyAttributes($property_name);
     }
@@ -110,7 +110,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testgetPropertyAttributesWithExistingPropertyName(string $class, string $property_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getPropertyAttributes($property_name)[$attribute_name])->getName();
         $this->assertSame($expected, $actual);
     }
@@ -125,7 +125,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testGetPropertyAttributeByPropertyNameWithNonExistingPropertyName(string $class, string $property_name, string $attribute_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(PropertyNotFoundException::class);
         $reader->getPropertyAttribute($property_name, $attribute_name);
     }
@@ -140,7 +140,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testGetPropertyAttributeByPropertyNameWithNonExistingAttributeName(string $class, string $property_name, string $attribute_name): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $this->expectException(PropertyAttributeNotFoundException::class);
         $reader->getPropertyAttribute($property_name, $attribute_name);
     }
@@ -175,7 +175,7 @@ class ReaderPropertyAttributesTest extends TestCase
      */
     public function testgetPropertyAttributeWithExistingPropertyName(string $class, string $property_name, string $attribute_name, mixed $expected): void
     {
-        $reader = new Reader($class);
+        $reader = new AttributesReader($class);
         $actual = ($reader->getPropertyAttribute($property_name,$attribute_name))->getName();
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
Renamed Reader class to AttributesReader and updated usages and tests.


Unit Tests results

```
/app # ./vendor/bin/phpunit --testdox
PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.6
Configuration: /app/phpunit.xml

...............................................................  63 / 109 ( 57%)
..............................................                  109 / 109 (100%)

Time: 00:00.032, Memory: 8.00 MB

Argument (AntonDPerera\PHPAttributesReader\Tests\Argument)
 ✔ When argument value is empty with data set 0
 ✔ When argument value is empty with data set 1
 ✔ When argument value is empty with data set 2
 ✔ When argument value is empty with data set 3
 ✔ When argument value is empty with data set 4
 ✔ When argument value is boolean with data set 0
 ✔ When argument value is boolean with data set 1
 ✔ When argument value is sequential array with data set 0
 ✔ When argument value is sequential array with data set 1
 ✔ When argument value is sequential array with data set 2
 ✔ When argument value is sequential array with data set 3
 ✔ When argument value is associative array with data set 0
 ✔ When argument value is associative array with data set 1
 ✔ When argument value is associative array with data set 2
 ✔ When argument value is associative array with data set 3
 ✔ When argument value is associative array with data set 4
 ✔ When argument value is associative array with data set 5
 ✔ When argument value is object with data set 0
 ✔ When argument value is object with data set 1
 ✔ When argument value is object with data set 2
 ✔ When argument value is object with data set 3
 ✔ When argument value is object with data set 4
 ✔ When argument value is a simple data type with data set 0
 ✔ When argument value is a simple data type with data set 1
 ✔ When argument value is a simple data type with data set 2
 ✔ When argument value is a simple data type with data set 3
 ✔ When argument value is a simple data type with data set 4
 ✔ When argument value is a simple data type with data set 5
 ✔ When argument value is a simple data type with data set 6
 ✔ When argument value is a simple data type with data set 7
 ✔ When argument value is a simple data type with data set 8

Attribute (AntonDPerera\PHPAttributesReader\Tests\Attribute)
 ✔ Exception when invalid reflection attribute given with data set 0
 ✔ Exception when invalid reflection attribute given with data set 1
 ✔ Exception when invalid reflection attribute given with data set 2
 ✔ Exception when invalid reflection attribute given with data set 3
 ✔ Get name with data set 0
 ✔ Get name with data set 1
 ✔ Has arguments with data set 0
 ✔ Has arguments with data set 1
 ✔ Has arguments with data set 2
 ✔ Has arguments with data set 3
 ✔ Has arguments with data set 4
 ✔ Get arguments with data set 0
 ✔ Get arguments with data set 1
 ✔ Get arguments with data set 2
 ✔ Get arguments with data set 3
 ✔ Get arguments with data set 4
 ✔ Get arguments with data set 5
 ✔ Get arguments with data set 6
 ✔ Get arguments with data set 7
 ✔ Get arguments with data set 8

Reader Class Attributes (AntonDPerera\PHPAttributesReader\Tests\ReaderClassAttributes)
 ✔ Exception when invalid class value given with data set 0
 ✔ Exception when invalid class value given with data set 1
 ✔ Exception when invalid class value given with data set 2
 ✔ Exception when invalid class value given with data set 3
 ✔ Exception when non existing class given with data set 0
 ✔ Exception when non existing class given with data set 1
 ✔ Exception when non existing class given with data set 2
 ✔ Exception when non existing class given with data set 3
 ✔ Get class attributes with no attributes class with data set 0
 ✔ Has class attributes with data set 0
 ✔ Has class attributes with data set 1
 ✔ Has class attributes with data set 2
 ✔ Has class attributes with data set 3
 ✔ Get class attributes without arguments with data set 0
 ✔ Get class attributes without arguments with data set 1
 ✔ Get class attributes without arguments with data set 2
 ✔ Get class attributes without arguments with data set 3
 ✔ Get class attributes with arguments with data set 0
 ✔ Get class attributes with arguments with data set 1
 ✔ Get class attributes with arguments with data set 2
 ✔ Get class attributes with arguments with data set 3
 ✔ Get class attributes with arguments with data set 4
 ✔ Get class attributes with arguments with data set 5
 ✔ Get class attributes with arguments with data set 6
 ✔ Get class attributes with arguments with data set 7
 ✔ Get class attributes with arguments with data set 8
 ✔ Exception when non existing attribute name given with data set 0
 ✔ Get class attribute by attribute name with data set 0
 ✔ Get class attribute by attribute name with data set 1
 ✔ Get class attribute by attribute name with data set 2
 ✔ Get class attribute by attribute name with data set 3
 ✔ Get class attribute by attribute name with data set 4

Reader Method Attributes (AntonDPerera\PHPAttributesReader\Tests\ReaderMethodAttributes)
 ✔ Get all method attributes with no attributes with data set 0
 ✔ Get all method attributes with attributes with data set 0
 ✔ Get all method attributes with attributes with data set 1
 ✔ Get all method attributes with attributes with data set 2
 ✔ Get method attributes with non existing method name with data set 0
 ✔ Get method attributes with existing method name with data set 0
 ✔ Get method attributes with existing method name with data set 1
 ✔ Get method attributes with existing method name with data set 2
 ✔ Get method attribute by method name with non existing method name with data set 0
 ✔ Get method attribute by method name with non existing attribute name with data set 0
 ✔ Get method attribute with existing method name with data set 0
 ✔ Get method attribute with existing method name with data set 1
 ✔ Get method attribute with existing method name with data set 2

Reader Property Attributes (AntonDPerera\PHPAttributesReader\Tests\ReaderPropertyAttributes)
 ✔ Get all property attributes with no attributes with data set 0
 ✔ Get all property attributes with attributes with data set 0
 ✔ Get all property attributes with attributes with data set 1
 ✔ Get all property attributes with attributes with data set 2
 ✔ Get property attributes with non existing property name with data set 0
 ✔ Get property attributes with existing property name with data set 0
 ✔ Get property attributes with existing property name with data set 1
 ✔ Get property attributes with existing property name with data set 2
 ✔ Get property attribute by property name with non existing property name with data set 0
 ✔ Get property attribute by property name with non existing attribute name with data set 0
 ✔ Get property attribute with existing property name with data set 0
 ✔ Get property attribute with existing property name with data set 1
 ✔ Get property attribute with existing property name with data set 2

OK (109 tests, 109 assertions)
```